### PR TITLE
Add middleman-framer to templates

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -107,4 +107,8 @@
   description: Slim, Sass, Bourbon & Neat with a boilerplate base and some <a href="https://github.com/shkm/middleman-neato/blob/master/README.md#features">nifty features</a>.
   links:
     github: https://github.com/shkm/middleman-neato
-
+-
+  name: middleman-framer
+  description: A <a href="http://framerjs.com">Framer.js</a> template for Middleman.
+  links:
+    github: https://github.com/shkm/middleman-neato


### PR DESCRIPTION
Adds https://github.com/bleikamp/middleman-framer to the templates directory
