### PR TITLE
Delete middleman-jellyfish

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -5,12 +5,6 @@
     github: https://github.com/polymatt/slimmer
   tags: ['slim', 'compass', 'coffeescript', 'bower', 'github pages', 'sublime text']
 -
-  name: Jellyfish
-  description: Twitter Bootstrap 3(RC.1),Coffee script,RequireJS,AngularJS,HAML. Everything you need to build a fast reponsive and robust website
-  links:
-    github: https://github.com/kodeslacker/middleman-jellyfish
-  tags: ['angular','twitter bootstrap','middleman','coffee script','requirejs']
--
   name: Amicus
   description: HTML5 Boilerplate 4.0, Sass, Compass & Susy with a responsive layout and up-to-date components.
   links:


### PR DESCRIPTION
Because this repository was gone https://github.com/kodeslacker/middleman-jellyfish

(Pointed at https://github.com/middleman/middleman-directory/pull/10#issuecomment-26708021 too)
