### PR TITLE
fixed middleman-foundation description, added appropriate tag

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -18,10 +18,10 @@
   tags: []
 -
   name: Middleman-Foundation
-  description: ZURB Foundation in Compass, SCSS & HAML.
+  description: ZURB Foundation in SCSS.
   links:
     github: https://github.com/vocino/middleman-foundation
-  tags: []
+  tags: [ZURB Foundation]
 -
   name: Middleman-Foundation-SMACSS
   description: ZURB Foundation in Compass, SCSS & HAML & following the SMACSS style guide.


### PR DESCRIPTION
The middleman-foundation template now uses the standalone SCSS branch as an upstream to keep it up to date with less clutter.  Using the Compass Foundation gem means you don't really need a middleman template (since all it would be is the Gemfile), so I cleaned up the project with just the essentials.
