### PR TITLE
Update templates.yml

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -29,6 +29,12 @@
     github: https://github.com/theblacksmith/chubbs
   tags: []
 -
+  name: Middleman-Zurb-Foundation
+  description: Middleman Skeleton For Zurb Foundation 5 (SASS version).
+  links:
+    github: https://github.com/axyz/middleman-zurb-foundation
+  tags: [ZURB Foundation SASS]
+-
   name: Middleman-Foundation
   description: ZURB Foundation in SCSS.
   links:
@@ -40,12 +46,6 @@
   links:
     github: https://github.com/hhg2288/foundation-smacss-middleman
   tags: []
--
-  name: Middleman-Zurb-Foundation
-  description: Middleman Skeleton For Zurb Foundation (SASS version).
-  links:
-    github: https://github.com/axyz/middleman-zurb-foundation
-  tags: [ZURB Foundation SASS]
 -
   name: Middleman-Frameless
   description: Basic project template with adaptive SASS grid from <a href="http://framelessgrid.com/">Frameless</a>.


### PR DESCRIPTION
Zurb Foundation template compatible with new version 5. It now uses bower for the framework dependency management as suggested by zurb in their last release.
