### PR TITLE
Added middleman-spellcheck

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -189,3 +189,11 @@
     - Bower
     - Coffeescript
     - jQuery
+-
+  name: middleman-spellcheck
+  description: "Run the aspell spell checker after the assets have been built"
+  links:
+    github: https://github.com/minivan/middleman-spellcheck
+  official: false
+  tags:
+    - Tooling


### PR DESCRIPTION
Added the `middleman-spellcheck` thingie. It's a small `after_build` hook that uses `aspell`. Especially useful for documentation sites.
