### PR TITLE
add duo color blog template

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -191,3 +191,9 @@
   links:
     github: https://github.com/denisfl/thane/
   tags: ['HTML5 Boilerplate', 'Bootstrap', 'Slim', 'SCSS']
+-
+  name: Duo Color
+  description: Duo Color — universal template for Middleman. Blog-aware, bootstrap, internationalization, latex, privacy-aware defaults
+  links:
+    github: https://github.com/rriemann/middleman-blog-template-duocolor
+  tags: ['bower', 'bootstrap', 'slim', 'markdown', 'SCSS', 'mobile', 'compass', 'blog']


### PR DESCRIPTION
I already announced the new template on twitter. I would like to add it to the directory to make it public.

Demo:
http://rriemann.github.io/middleman-blog-template-duocolor/
