### PR TITLE
Add Middleman Search Engine Sitemap

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -222,3 +222,11 @@
   tags:
     - Tooling
     - Assets
+-
+  name: middleman-search_engine_sitemap
+  description: Tell search engines which pages are most important in your Middleman site.
+  official: false
+  links:
+    github: https://github.com/Aupajo/middleman-search_engine_sitemap
+  tags:
+    - Generator


### PR DESCRIPTION
Tell search engines which pages are most important in your Middleman site. 
