### PR TITLE
Add middleman-google-analytics

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -239,7 +239,6 @@
     github: https://github.com/Aupajo/middleman-search_engine_sitemap
   tags:
     - Generator
-
 -
   name: middleman-sitemap
   description: Generate sitemaps for your Middleman site with options for GZIP and hostname
@@ -257,7 +256,6 @@
     - original
   tags:
     - Tooling
-
 -
   name: middleman-meta-tags
   description: Easy integration of meta tags into your Middleman applications
@@ -266,7 +264,6 @@
     github: https://github.com/tiste/middleman-meta-tags
   tags:
     - Tooling
-
 -
   name: middleman-webp
   description: Generates WebP alternatives for each image file during build.
@@ -276,7 +273,6 @@
   tags:
     - Tooling
     - Assets
-
 -
   name: middleman-ogp
   description: Adds OpenGraph Helper.
@@ -285,3 +281,12 @@
     github: https://github.com/ngs/middleman-ogp
   tags:
     - Generator
+-
+  name: middleman-google-analytics
+  description: Generate your Google Analytics tracking code.
+  official: false
+  links:
+    github: https://github.com/danielbayerlein/middleman-google-analytics
+  tags:
+    - Generator
+    - Tooling


### PR DESCRIPTION
middleman-google-analytics is a Middleman extension that generates Google Analytics tracking code, and keeps the config in config.rb, where it belongs.
