### PR TITLE
Adding middleman-cdn extension.

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -389,4 +389,11 @@
     github: https://github.com/bryanbraun/middleman-navtree
   tags:
     - Generator
-
+-
+  name: middleman-cdn
+  description: Automatic invalidation of CloudFlare and Amazon CloudFront CDN cache.
+  official: false
+  links:
+    github: https://github.com/leighmcculloch/middleman-cdn
+  tags:
+    - Deployment


### PR DESCRIPTION
Based off middleman-cloudfront and re-designed to support growing with more CDNs.
