### PR TITLE
Fix typo

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -50,7 +50,7 @@
   name: Middleman-Foundation5-Basic
   description: Foundation 5, SCSS, HAML and Coffee Script. Modular structure for css/scss files. Rails like assets structure.
   links:
-  github: hhttps://github.com/RalphAtHamburg/middleman-foundation5-basic
+    github: https://github.com/RalphAtHamburg/middleman-foundation5-basic
   tags: ['ZURB Foundation', 'Foundation 5', 'Sass', 'HAML', 'CoffeeScript']
 -
   name: Middleman-Foundation-SMACSS


### PR DESCRIPTION
GitHub link was not displayed at the templates directory page.
