### PR TITLE
Added middleman-middlemac

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -278,3 +278,13 @@
     - SCSS
     - Slim
     - Font Awesome
+-
+  name: middleman-middlemac
+  description: A project template and extension for creating proper Mac OS X .help files for applications. Works on any OS that Middleman supports.
+  links:
+    github: https://github.com/balthisar/middlemac
+  tags:
+    - Mac
+    - XCode
+    - Cocoa
+    - Help Files


### PR DESCRIPTION
Middleman is _also_ an ideal tool for creating Mac OS X help files. This template and included extension takes all the work out of getting things just right for Mac OS X help files to function with Xcode projects and applications.
