### PR TITLE
add middleman-haml-heroku to templates

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -311,3 +311,12 @@
     - SCSS
     - Slim
     - Font Awesome
+-
+  name: middleman-haml-heroku
+  description: A Middleman HAML, SASS, production ready Heroku Boilerplate Template.
+  links:
+    github: https://github.com/austinlchang/middleman-haml-heroku
+  tags:
+    - HAML
+    - SCSS
+    - Heroku


### PR DESCRIPTION
add template: middleman-haml-heroku, a middleman template that uses HAML for views and is ready to deploy to heroku
