### PR TITLE
Fix for wrong typo in repository url

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -56,7 +56,7 @@
   name: Middleman-Foundation5-Basic
   description: Foundation 5, SCSS, HAML and Coffee Script. Modular structure for css/scss files. Rails like assets structure.
   links:
-  github: hhttps://github.com/RalphAtHamburg/middleman-foundation5-basic
+    github: https://github.com/RalphAtHamburg/middleman-foundation5-basic
   tags: ['ZURB Foundation', 'Foundation 5', 'Sass', 'HAML', 'CoffeeScript']
 -
   name: Middleman-Foundation-SMACSS


### PR DESCRIPTION
There was a typing error in the url for the git repository
