### PR TITLE
add statistrano to list of deployment extensions

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -491,3 +491,11 @@
     github: https://github.com/marnen/middleman-breadcrumbs
   tags:
     - Navigation
+-
+  name: statistrano
+  description: Deploy any static site via rsync as versioned releases or feature branches.
+  official: false
+  links:
+    github: https://github.com/mailchimp/statistrano
+  tags:
+    - Deployment


### PR DESCRIPTION
Technically not a _middleman_ extension as it works with any static site, but it was built for middleman initially (and is how we deploy all of our middleman sites).

Feel free to close if you feel it's out of bounds.

cheers,
steven
