### PR TITLE
this link to template sends to 404

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -172,12 +172,6 @@
     github: https://github.com/tombryan/middleman_starter
   tags: ['mobile first']
 -
-  name: Middleman-Bootstrap-Bower
-  description: Bootstrap + Middleman + Bower template.
-  links:
-    github: https://github.com/razorfly/middleman-bootstrap-template
-  tags: ['bootstrap', 'bower', 'markdown']
--
   name: Personal Site Template
   description: A personal website using Zurb Foundation. Features a portfolio, blog, easy configuration-based setup, and Sass-based theming.
   links:


### PR DESCRIPTION
@tdreyno was doing some template config research and while looking at bootstrap templates here... noticed that the middleman-bootstrap-bower template sent me to a 404. Looked for the repo elsewhere and couldn't find so I removed it.
