### PR TITLE
Add Mail2FrontMatter extension to extensions.yml

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -534,3 +534,12 @@
     - Email
     - Security
     
+-
+  name: Mail2FrontMatter
+  description: allows you to email updates to your blog
+  official: false
+  links:
+    github: https://github.com/whistlerbrk/mail2frontmatter
+  tags:
+    - Email
+    


### PR DESCRIPTION
Hello, I've created a gem designed for Middleman specifically (and down the road possibly Jekyll)

And I've described it in more detail here:
https://forum.middlemanapp.com/t/email-your-middleman-blog/1601

Thanks!