### PR TITLE
bumped bourbon to 4.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem 'middleman', "~> 3.3.0"
 gem 'zurb-foundation', '~> 4.0', require: 'foundation/sprockets'
-gem 'bourbon', '~> 4.0.2'
+gem 'bourbon', '~> 4.2.1'
 gem 'neat', '~> 1.7.0'
 
 gem 'middleman-ember', '~> 0.1.1'


### PR DESCRIPTION
Bumps the gem `bourbon` to `4.2.1` due to me getting [this Sass compilation error](http://puu.sh/gM4OB/0f9c2e0af3.png) and this resolving the issue (as mentioned [in this comment](https://github.com/middleman/middleman-directory/pull/89#discussion_r26922804)).

I quickly eyeballed the index and it seemed to just as before :)

Cheers
Patrik