### PR TITLE
add new extension

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -616,3 +616,12 @@
     - Font Awesome
     - Analytics
     - Mobile
+-
+  name: middleman-org
+  description: Middleman org-mode extension
+  links:
+    github: https://github.com/xiaoxinghu/middleman-org
+  supported_api_versions:
+    - original
+  tags:
+    - org-mode


### PR DESCRIPTION
middleman-org is org-mode extension for middleman. Check the [README](https://github.com/xiaoxinghu/middleman-org/blob/master/README.md) for more info.