### PR TITLE
Add middleman-dokku extension

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -635,3 +635,15 @@
     - original
   tags:
     - Assets
+
+-
+  name: middleman-dokku
+  description: Deploy a middleman site to a Dokku instance
+  links:
+    github: https://github.com/ngmaloney/middleman-dokku
+  official: false
+  supported_api_versions:
+    - original
+  tags:
+    - Deployment
+    - Dokku


### PR DESCRIPTION
Middleman-dokku is a simple rake task that generates a Dokku compatible config.ru and Procfile for a middleman site. Once deployed to a Dokku instance the site will be served up via Rack TryStatic.