### PR TITLE
Fixes double Blog-tag

### DIFF
--- a/data/templates.yml
+++ b/data/templates.yml
@@ -233,7 +233,7 @@
   description: Duo Color — universal template for Middleman. Blog-aware, bootstrap, internationalization, latex, privacy-aware defaults
   links:
     github: https://github.com/rriemann/middleman-blog-template-duocolor
-  tags: ['bower', 'bootstrap', 'slim', 'markdown', 'SCSS', 'mobile', 'compass', 'blog']
+  tags: ['bower', 'bootstrap', 'slim', 'markdown', 'SCSS', 'mobile', 'compass', 'Blog']
 -
   name: Landed by HTML5 UP for Middleman4
   description: Responsive website template usking skel. This is an adaption of the the template Landed by HTML5 UP. Demo online at http://html5up.net/landed


### PR DESCRIPTION
The blog tag was showing twice.

<img width="463" alt="screenshot 2015-10-07 23 19 09" src="https://cloud.githubusercontent.com/assets/11569296/10351459/f9d7e7d0-6d49-11e5-8fe2-8a4e3905bec1.png">
