### PR TITLE
Add middleman-scavenger extension

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -698,3 +698,14 @@
     - Tooling
     - Search
     - Lunr.js
+-
+  name: middleman-scavenger
+  description: Automatically create and use SVG sprite sheets
+  links:
+    github: https://github.com/varvet/middleman-scavenger
+  official: false
+  supported_api_versions:
+    - original
+  tags:
+    - Assets
+    - Tooling


### PR DESCRIPTION
Middleman-scavenger is an extension for automatically discovering and
combining SVG files into a sprite sheet that can be asynchronously
loaded or inlined into a middleman site.