### PR TITLE
add middleman-foxycart

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -729,3 +729,13 @@
     - Assets
     - Helpers
     - WebPerf
+-
+  name: middleman-foxycart
+  description: FoxyCart (hosted eCommerce) helpers to generate product links (including HMAC verficiation links) and include the required Javascript in your templates.
+  links:
+    github: https://github.com/rjocoleman/middleman-foxycart
+  supported_api_versions:
+    - original
+  tags:
+    - Helpers
+    - Operations


### PR DESCRIPTION
Adds [`middleman-foxycart`] (https://github.com/rjocoleman/middleman-foxycart), a small set of view helpers for [FoxyCart](https://www.foxycart.com/) an a hosted ecommerce shopping cart/checkout.

It's a Middleman specific abstraction of https://github.com/rjocoleman/foxycart_helpers#foxycart-helpers