### PR TITLE
Adding PubStorm to middleman services directory

### DIFF
--- a/data/services.yml
+++ b/data/services.yml
@@ -26,3 +26,15 @@
     - Paid
     - AutomaticDeployment
     - GithubPages
+-
+  name: PubStorm
+  description: |-
+    Lightning fast, 100% free publishing and hosting platform for middleman projects, static sites and single-page javascript applications. Production-grade CDN, free SSL, custom domains, collaboration and more. <a href="https://www.pubstorm.com">Publish your middleman site for free</a>.
+  links:
+    site: https://www.pubstorm.com
+  tags:
+    - Free
+    - Paid
+    - CDN
+    - Custom Domains
+    - SSL


### PR DESCRIPTION
We have a middleman development template on [Nitrous](https://www.nitrous.io) and recently built a static site hosting service for Nitrous users. It's a great resource for those who have multiple static projects to host, want free ssl support, etc.. PTAL!