### PR TITLE
Added middleman-related-articles

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -872,3 +872,12 @@
   tags:
     - accessibility
     - helpers
+-
+  name: middleman-related-articles
+  description: Automatically identify related articles in your Middleman blog
+  links:
+    github: https://github.com/dsedivec/middleman-related-articles
+  supported_api_versions:
+    - original
+  tags:
+    - Tooling


### PR DESCRIPTION
This is an extension for Middleman's blog extension to automatically identify recent articles using latent semantic indexing (LSI), a fancy algorithm for identifying relationships between unstructured texts.