### PR TITLE
Add CDN tag to middleman-cdn

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -513,6 +513,7 @@
     github: https://github.com/leighmcculloch/middleman-cdn
   tags:
     - Deployment
+    - CDN
 -
   name: middleman-disqus
   description: "A Middleman extension to integrate Disqus into your site, supporting Disqus configuration variables and comment counts."


### PR DESCRIPTION
What
===
Add `CDN` tag to `middleman-cdn` extension.

Why
===
The `middleman-cdn` extension is used for invalidating CDNs caches when deploying middleman sites.