### PR TITLE
Fix typo in tag name

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -938,7 +938,7 @@
   supported_api_versions:
     - v4
   tags:
-    - Generators
+    - Generator
     - Tooling
 -
   name: middleman-hotjar


### PR DESCRIPTION
All of the other entries just have Generator without the `s`