### PR TITLE
Add middleman-importmap extensions

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -970,3 +970,14 @@
     github: https://github.com/seibii/middleman-rss_items
   tags:
     - Generator
+
+-
+  name: middleman-importmap
+  description: Import Maps support to Middleman.
+  official: false
+  links:
+    github: https://github.com/dvinciguerra/middleman-importmap
+  tags:
+    - Tooling
+    - Assets
+    - Optimization


### PR DESCRIPTION
Middleman Importmap extension adds support for Import Maps using polyfill (for grant browsers support) and uses the native es6 browser support with module imports.